### PR TITLE
updated commands to run request-baskets service in docker container: …

### DIFF
--- a/docker/golang/Dockerfile
+++ b/docker/golang/Dockerfile
@@ -8,3 +8,6 @@ MAINTAINER Vladimir L, vladimir_l@gmx.net
 
 # Expose ports
 EXPOSE 55555
+
+# We need to change default binding ip
+CMD ["go-wrapper", "run", "-l", "0.0.0.0"]

--- a/docker/minimal/Dockerfile
+++ b/docker/minimal/Dockerfile
@@ -15,4 +15,4 @@ COPY request-baskets /usr/local/bin/
 # Expose ports
 EXPOSE 55555
 
-CMD request-baskets -db bolt -file /var/lib/rbaskets/baskets.db
+CMD request-baskets -l 0.0.0.0 -db bolt -file /var/lib/rbaskets/baskets.db

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -25,4 +25,4 @@ RUN set -x \
 # Expose ports
 EXPOSE 55555
 
-CMD request-baskets -db bolt -file /var/lib/rbaskets/baskets.db
+CMD request-baskets -l 0.0.0.0 -db bolt -file /var/lib/rbaskets/baskets.db


### PR DESCRIPTION
…bind to 0.0.0.0 ip instead of default 127.0.0.1 which is not exposed