### PR TITLE
Allow configuring service in multistage container via environment.

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+if [ -z "$LISTEN" ]; then
+    LISTEN="0.0.0.0"
+fi
+
+if [ -z "$DB" ]; then
+    DB="bolt"
+fi
+
+if [ -z "$FILE" ]; then
+    FILE="/var/lib/rbaskets/baskets.db"
+fi
+
+args="-l $LISTEN -db $DB -file $FILE"
+
+if [ -n "$CONN" ]; then
+    args="$args -conn $CONN"
+fi
+
+if [ -n "$PORT" ]; then
+    args="$args -p $PORT"
+fi
+
+if [ -n "$PAGE" ]; then
+    args="$args -page $PAGE"
+fi
+
+if [ -n "$SIZE" ]; then
+    args="$args -size $SIZE"
+fi
+
+if [ -n "$MAXSIZE" ]; then
+    args="$args -maxsize $MAXSIZE"
+fi
+
+if [ -n "$TOKEN" ]; then
+    args="$args -token $TOKEN"
+fi
+
+cmd="/bin/rbaskets $args"
+echo "Executing: $cmd"
+exec $cmd

--- a/docker/multistage/Dockerfile
+++ b/docker/multistage/Dockerfile
@@ -18,6 +18,7 @@ FROM alpine:latest
 MAINTAINER Vladimir L, vladimir_l@gmx.net
 RUN apk --no-cache add ca-certificates
 VOLUME /var/lib/rbaskets
+COPY docker/entrypoint.sh /bin/entrypoint
 COPY --from=builder /go/bin/rbaskets /bin/rbaskets
 EXPOSE 55555
-CMD /bin/rbaskets -l 0.0.0.0 -db bolt -file /var/lib/rbaskets/baskets.db
+CMD /bin/entrypoint


### PR DESCRIPTION
This allows running the service with non-default options in the provided multistage-build container.

The point could be made, that it'd be cleaner if the application itself pulled settings, the value of which wasn't configured via CLI, from the environment. But your choice whether you want to go this way. :)

I did not know if you still maintained the `ubuntu` and `minimal` builds, so did not bother adding it in those Dockerfiles - but it should be rather straight-forward to add if desired.