### PR TITLE
add headers to templated html response

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -489,6 +489,10 @@ func writeBasketResponse(w http.ResponseWriter, r *http.Request, name string, ba
 	}
 
 	// body
+	data := map[string]interface{}{
+		"query":r.URL.Query(),
+		"headers":r.Header,
+	}
 	if response.IsTemplate && len(response.Body) > 0 {
 		// template
 		t, err := template.New(name + "-" + r.Method).Parse(response.Body)
@@ -499,7 +503,7 @@ func writeBasketResponse(w http.ResponseWriter, r *http.Request, name string, ba
 			// status
 			w.WriteHeader(response.Status)
 			// templated body
-			t.Execute(w, r.URL.Query())
+			t.Execute(w, data)
 		}
 	} else {
 		// status


### PR DESCRIPTION
With this change not only query params but the headers are also available in templated html response.

There are at least 2 use cases which would be covered:
- could be used as an upstream for [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy)
- could be used for various webhooks, which expect a json response with some header/query values

```
$ BASKET=getuser
$ URL=https://rbaskets.in

$ T=$(curl -s ${URL}/api/baskets/${BASKET} -d '' | jq .token -r )

$ curl -X PUT -H "Authorization: $T" ${URL}/api/baskets/${BASKET}/responses/GET \
  -d '{"status":200,"headers":{},"body":"user: {{ index .headers \"X-Forwarded-Preferred-Username\" }}\nemail: {{ index .headers \"X-Forwarded-Email\" }}","is_template":true}'


## test
$ curl -H "X-Forwarded-Preferred-Username: fake" -H "X-Forwarded-Email: fake@ema.il" ${URL}/${BASKET}

user: [fake]
email: [fake@ema.il]


```