### PR TITLE
Docker Action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,67 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ "master" ]
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: ${{ vars.DOCKERHUB_IMAGENAME }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=${{ github.head_ref || github.ref_name }} # source or commit branch name
+
+      - name: Git Short SHA
+        id: git_vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/multistage/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            GIT_VERSION=${{ github.ref_name }}
+            GIT_COMMIT=${{ github.sha }}
+            GIT_COMMIT_SHORT=${{ steps.git_vars.outputs.sha_short }}
+

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,11 +34,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            ghcr.io/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,8 +8,10 @@ on:
     branches: [ "master" ]
 
 env:
-  REGISTRY: docker.io
-  IMAGE_NAME: ${{ vars.DOCKERHUB_IMAGENAME }}
+  DOCKERHUB_REGISTRY: docker.io
+  GITHUB_REGISTRY: ghcr.io
+  DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGENAME }}
+  GITHUB_IMAGE: ${{ github.repository }}
 
 jobs:
   build:
@@ -46,8 +48,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            ghcr.io/${{ env.IMAGE_NAME }}
+            ${{ env.DOCKERHUB_REGISTRY }}/${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.GITHUB_REGISTRY }}/${{ env.GITHUB_IMAGE }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/docker/multistage/Dockerfile
+++ b/docker/multistage/Dockerfile
@@ -2,19 +2,21 @@
 # Version 1.3
 
 # Stage 1. Building service
-FROM golang:latest as builder
+FROM --platform=$BUILDPLATFORM golang:latest as builder
 WORKDIR /go/src/rbaskets
 COPY . .
-RUN GIT_VERSION="$(git describe --dirty='*' || git symbolic-ref -q --short HEAD)" \
-  && GIT_COMMIT="$(git rev-parse HEAD)" \
-  && GIT_COMMIT_SHORT="$(git rev-parse --short HEAD)" \
-  && set -x \
-  && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo \
-    -ldflags="-w -s -X main.GitVersion=${GIT_VERSION} -X main.GitCommit=${GIT_COMMIT} -X main.GitCommitShort=${GIT_COMMIT_SHORT}" \
-    -o /go/bin/rbaskets
+ARG TARGETARCH
+ARG GIT_VERSION
+ARG GIT_COMMIT
+ARG GIT_COMMIT_SHORT
+
+RUN set -x \
+  && CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -installsuffix cgo \
+  -ldflags="-w -s -X main.GitVersion=${GIT_VERSION} -X main.GitCommit=${GIT_COMMIT} -X main.GitCommitShort=${GIT_COMMIT_SHORT}" \
+  -o /go/bin/rbaskets
 
 # Stage 2. Packaging into alpine
-FROM alpine:latest
+FROM --platform=$TARGETPLATFORM alpine:latest
 LABEL maintainer="vladimir_l@gmx.net"
 RUN apk --no-cache add ca-certificates
 VOLUME /var/lib/rbaskets


### PR DESCRIPTION
Docker Build Action for ARM64 + AMD64

For: https://github.com/darklynx/request-baskets/issues/58

Pushes docker images on pull requests into master, changes to master, and on version tags.

Setup needed:

- DOCKERHUB_USERNAME (repository action secret)
- DOCKERHUB_TOKEN (repository action secret)
- DOCKERHUB_IMAGENAME (repository variable)

There's a quirk with the v prefix when tagging in a release, so a Github tag/release for v1.2.3 creates five tags:

- v1.2.3
- 1.2.3
- 1.2
- 1
- latest

https://github.com/docker/metadata-action/issues/422